### PR TITLE
refactor: changing background color of selector when disabled and adding ellipsis on editText components

### DIFF
--- a/aiqcomponents/src/main/java/com/aiqfome/aiqcomponents/selector/Selector.java
+++ b/aiqcomponents/src/main/java/com/aiqfome/aiqcomponents/selector/Selector.java
@@ -10,6 +10,7 @@ import android.view.LayoutInflater;
 import android.widget.LinearLayout;
 
 import androidx.annotation.Nullable;
+import androidx.core.content.ContextCompat;
 import androidx.vectordrawable.graphics.drawable.VectorDrawableCompat;
 
 import com.aiqfome.aiqcomponents.R;
@@ -35,6 +36,7 @@ public class Selector extends LinearLayout {
         root = findViewById(R.id.root);
         inputLayout = findViewById(R.id.input_layout);
         editText = findViewById(R.id.et_input);
+        editText.setKeyListener(null);
         Drawable icChevronDown = VectorDrawableCompat.create(context.getResources(),
                 R.drawable.ic_chevron_down, context.getTheme());
         editText.setCompoundDrawablesWithIntrinsicBounds(null, null, icChevronDown, null);
@@ -111,11 +113,17 @@ public class Selector extends LinearLayout {
 
         editText.setEnabled(enabled);
         editText.setClickable(enabled);
+
+        if (!enabled) {
+            int color = ContextCompat.getColor(getContext(), R.color.colorDivider);
+            editText.setBackgroundColor(color);
+        }
     }
 
     public void setSelectedItem(String itemText) {
         this.editText.setText(itemText);
     }
+
 
     public SelectorController getController() {
         return controller;

--- a/aiqcomponents/src/main/java/com/aiqfome/aiqcomponents/textinput/TextInput.java
+++ b/aiqcomponents/src/main/java/com/aiqfome/aiqcomponents/textinput/TextInput.java
@@ -3,7 +3,9 @@ package com.aiqfome.aiqcomponents.textinput;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
+import android.text.TextUtils;
 import android.text.method.DigitsKeyListener;
+import android.text.method.KeyListener;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.util.TypedValue;
@@ -30,6 +32,7 @@ public class TextInput extends ConstraintLayout {
     private TextInputEditText input;
     private TextInputLayout inputLayout;
     private ImageView icon;
+    private KeyListener inputKeyListener;
 
     public TextInput(Context context, @Nullable AttributeSet attrs) {
         super(context, attrs);
@@ -41,6 +44,8 @@ public class TextInput extends ConstraintLayout {
         input = findViewById(R.id.et_input);
         inputLayout = findViewById(R.id.input);
         icon = findViewById(R.id.iv_selected_icon);
+
+        inputKeyListener = input.getKeyListener();
 
         setupAttrs(context, attrs);
         setOnClickListener(onClickListener());
@@ -143,6 +148,27 @@ public class TextInput extends ConstraintLayout {
         }
 
         styledAttributes.recycle();
+    }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        this.input.setEnabled(enabled);
+        setEllipsized(!enabled);
+
+    }
+
+    private void setEllipsized(boolean enabled) {
+        this.input.setCursorVisible(!enabled);
+        if (enabled) {
+            this.input.setEllipsize(TextUtils.TruncateAt.END);
+            this.input.setKeyListener(null);
+
+            return;
+        }
+
+        this.input.setEllipsize(null);
+        this.input.setKeyListener(inputKeyListener);
     }
 
     private OnClickListener onClickListener() {

--- a/aiqcomponents/src/main/res/layout/selector.xml
+++ b/aiqcomponents/src/main/res/layout/selector.xml
@@ -28,10 +28,10 @@
             android:layout_height="match_parent"
             android:cursorVisible="false"
             android:ellipsize="end"
+            android:inputType="none"
+            android:scrollHorizontally="true"
             android:focusable="false"
             android:focusableInTouchMode="false"
-            android:inputType="textNoSuggestions"
-            android:lines="1"
             android:singleLine="true"
             android:textAppearance="@style/TextAppearance.aiq.BoldBody" />
 

--- a/aiqcomponents/src/main/res/layout/text_input.xml
+++ b/aiqcomponents/src/main/res/layout/text_input.xml
@@ -66,6 +66,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:fontFamily="@font/nunito_font_bold"
+            android:singleLine="true"
             android:textStyle="bold"
             android:textSize="20sp"
             android:maxLines="1" />

--- a/sample/src/main/java/com/aiqcomponents/sample/fragments/InputsFragment.kt
+++ b/sample/src/main/java/com/aiqcomponents/sample/fragments/InputsFragment.kt
@@ -47,7 +47,6 @@ class InputsFragment : Fragment(R.layout.fragment_inputs) {
                         .show()
             }
         }
-
         layoutInputsRoot.tiCountryPhone?.setup(countriesController)
     }
 

--- a/sample/src/main/res/layout/fragment_inputs.xml
+++ b/sample/src/main/res/layout/fragment_inputs.xml
@@ -42,5 +42,4 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="20dp"
         app:selectorTitle="city" />
-
 </LinearLayout>


### PR DESCRIPTION
the selector was the wrong background color when status was disabled and the editables text fields wasn't single lines.

now selectors and editables text fields is single line and with ellipsis when they're not editables.